### PR TITLE
Change way of installing pnpm on shared CI setup

### DIFF
--- a/.github/actions/ci-common-setup/action.yaml
+++ b/.github/actions/ci-common-setup/action.yaml
@@ -15,7 +15,7 @@ runs:
       shell: bash
 
     - name: Install pnpm
-      run: npm install -g pnpm
+      run: curl -fsSL https://get.pnpm.io/install.sh | sh -
       shell: bash
 
     - name: Restore possibly cached dependencies


### PR DESCRIPTION
Change way of installing pnpm on shared CI setup via curl directly in stead of through npm.