### PR TITLE
Fix release process attempt 3

### DIFF
--- a/.github/actions/ci-common-setup/action.yaml
+++ b/.github/actions/ci-common-setup/action.yaml
@@ -1,12 +1,19 @@
 name: Common Setup for CI
+
 description: Reusable common setup for project's CI jobs
+
+inputs:
+  node-version:
+    description: Specific Node.js version to override the common one that's gonna be selected by default
+    required: false
+    default: 'v16.14.0'
 
 runs:
   using: composite
   steps:
     - uses: actions/setup-node@v2
       with:
-        node-version: '16.14.0'
+        node-version: ${{ inputs.node-version }}
 
     - name: Get Node.js Version
       id: node_version

--- a/.github/workflows/release_new_version.yaml
+++ b/.github/workflows/release_new_version.yaml
@@ -8,6 +8,10 @@ on:
         default: false
         description: Perform as a dry run
 
+  pull_request: ### ### ###
+    branches: [master] ### ### ###
+
+
 jobs:
   release_new_version:
     runs-on: ubuntu-latest
@@ -18,34 +22,9 @@ jobs:
 
       - uses: ./.github/actions/ci-common-setup
         with:
-          node-version: v14 # setting this old Node version to work around a crush of the `cycjimmy/semantic-release-action@v3.4.2` action used here at the time of writing, reference: https://github.com/cycjimmy/semantic-release-action/issues/159#issuecomment-1538652646
+          node-version: v18
 
-      # - name: Get Node.js Version
-      #   id: node_version
-      #   run: |
-      #     echo "::set-output name=version::$(node -v)"
-      #   shell: bash
-
-      # - name: Install pnpm
-      #   run: npm install -g pnpm
-      #   shell: bash
-
-      # - name: Restore possibly cached dependencies
-      #   id: cache-node-modules
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ./node_modules
-      #     key: node-modules-${{ runner.os }}-${{ steps.node_version.outputs.version }}-${{ hashFiles('./pnpm-lock.yaml') }}
-
-      # - name: Install dependencies if weren't cached
-      #   if: steps.cache-node-modules.outputs.cache-hit != 'true'
-      #   run: pnpm install --frozen-lockfile
-      #   shell: bash
-
-      # - uses: actions/setup-node@v3
-      #   with:
-      #     node-version: v14 # setting this old Node version to work around a crush of the `cycjimmy/semantic-release-action@v3.4.2` action used here at the time of writing, reference: https://github.com/cycjimmy/semantic-release-action/issues/159#issuecomment-1538652646
-
+      # https://github.com/cycjimmy/semantic-release-action/issues/159
       - name: Semantic Release
         id: semantic_release
         uses: cycjimmy/semantic-release-action@v3.4.2
@@ -56,9 +35,9 @@ jobs:
           semantic_version: 19.0.5
           dry_run: ${{ inputs.dry_run }}
           extra_plugins: |
-            @semantic-release/commit-analyzer
-            @semantic-release/release-notes-generator
-            @semantic-release/changelog@6.0.0
-            @semantic-release/github
-            @semantic-release/npm
-            @semantic-release/git
+            @semantic-release/commit-analyzer@9.0.2
+            @semantic-release/release-notes-generator@10.0.3
+            @semantic-release/changelog@6.0.2
+            @semantic-release/github@8.0.7
+            @semantic-release/npm@9.0.2
+            @semantic-release/git@10.0.1

--- a/.github/workflows/release_new_version.yaml
+++ b/.github/workflows/release_new_version.yaml
@@ -16,9 +16,35 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
+      - uses: ./.github/actions/ci-common-setup
         with:
           node-version: v14 # setting this old Node version to work around a crush of the `cycjimmy/semantic-release-action@v3.4.2` action used here at the time of writing, reference: https://github.com/cycjimmy/semantic-release-action/issues/159#issuecomment-1538652646
+
+      # - name: Get Node.js Version
+      #   id: node_version
+      #   run: |
+      #     echo "::set-output name=version::$(node -v)"
+      #   shell: bash
+
+      # - name: Install pnpm
+      #   run: npm install -g pnpm
+      #   shell: bash
+
+      # - name: Restore possibly cached dependencies
+      #   id: cache-node-modules
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ./node_modules
+      #     key: node-modules-${{ runner.os }}-${{ steps.node_version.outputs.version }}-${{ hashFiles('./pnpm-lock.yaml') }}
+
+      # - name: Install dependencies if weren't cached
+      #   if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      #   run: pnpm install --frozen-lockfile
+      #   shell: bash
+
+      # - uses: actions/setup-node@v3
+      #   with:
+      #     node-version: v14 # setting this old Node version to work around a crush of the `cycjimmy/semantic-release-action@v3.4.2` action used here at the time of writing, reference: https://github.com/cycjimmy/semantic-release-action/issues/159#issuecomment-1538652646
 
       - name: Semantic Release
         id: semantic_release

--- a/.github/workflows/release_new_version.yaml
+++ b/.github/workflows/release_new_version.yaml
@@ -8,10 +8,6 @@ on:
         default: false
         description: Perform as a dry run
 
-  pull_request: ### ### ###
-    branches: [master] ### ### ###
-
-
 jobs:
   release_new_version:
     runs-on: ubuntu-latest
@@ -24,7 +20,7 @@ jobs:
         with:
           node-version: v18
 
-      # https://github.com/cycjimmy/semantic-release-action/issues/159
+      # The following action version, value of `semantic_version` and the versions of all the plugins specifically set here are a work around found for now to deal with the constant crush described here: https://github.com/cycjimmy/semantic-release-action/issues/159 (was hard to just go with the Node v14 suggestion said there since we use pnpm and it outright doesn't support Node v14)
       - name: Semantic Release
         id: semantic_release
         uses: cycjimmy/semantic-release-action@v3.4.2


### PR DESCRIPTION
Make the release job use the common action so it can have `pnpm` and all the project deps available and installed.