### PR TITLE
Modify rules release type rules

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,19 @@
 {
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          { "type": "docs", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "style", "release": "patch" }
+        ],
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
+        }
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/github",


### PR DESCRIPTION
Modify rules determining which release type results from which commit types.

Notably, included the `docs` commit type from now on also to result in _patch_ releases, since any type of docs edit eventually is made part of the released package, whether it is on the actual `README.md` file or edits of JSDoc blocks across the codebase.