### PR TITLE
Rename public type `Iterified` to `IterifiedIterable`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
-import { iterified, type Iterified, type IterifiedIterator } from './iterified';
+import {
+  iterified,
+  type Iterified,
+  type IterifiedIterable,
+  type IterifiedIterator,
+} from './iterified';
 import { iterifiedUnwrapped, type IterifiedUnwrapped } from './iterifiedUnwrapped';
 import { type ExecutorFn } from './utils/types/ExecutorFn';
 
@@ -7,6 +12,7 @@ export {
   iterifiedUnwrapped,
   type ExecutorFn,
   type Iterified,
+  type IterifiedIterable,
   type IterifiedUnwrapped,
   type IterifiedIterator,
 };

--- a/src/iterified.ts
+++ b/src/iterified.ts
@@ -1,9 +1,15 @@
 import { MulticastChannel, createMulticastChannel } from './utils/createMulticastChannel';
 import { type ExecutorFn } from './utils/types/ExecutorFn';
 
-export { iterified, type ExecutorFn, type Iterified, type IterifiedIterator };
+export {
+  iterified,
+  type ExecutorFn,
+  type IterifiedIterable,
+  type Iterified,
+  type IterifiedIterator,
+};
 
-function iterified<TNext>(executorFn: ExecutorFn<TNext>): Iterified<TNext> {
+function iterified<TNext>(executorFn: ExecutorFn<TNext>): IterifiedIterable<TNext> {
   let channel: MulticastChannel<TNext> | undefined;
   let suspendFurtherPushes = false;
   let activeIteratorCount = 0;
@@ -91,7 +97,16 @@ function iterified<TNext>(executorFn: ExecutorFn<TNext>): Iterified<TNext> {
   }
 }
 
-type Iterified<TNextValue, TDoneValue = undefined | void> = {
+/**
+ * @deprecated This type is deprecated - use {@link IterifiedIterable} instead.
+ * @see {@link IterifiedIterable}
+ */
+type Iterified<TNextValue, TDoneValue = undefined | void> = IterifiedIterable<
+  TNextValue,
+  TDoneValue
+>;
+
+type IterifiedIterable<TNextValue, TDoneValue = undefined | void> = {
   [Symbol.asyncIterator](): IterifiedIterator<TNextValue, TDoneValue>;
 };
 

--- a/src/iterifiedUnwrapped.ts
+++ b/src/iterifiedUnwrapped.ts
@@ -1,4 +1,4 @@
-import { type Iterified } from './iterified';
+import { type IterifiedIterable } from './iterified';
 import { createMulticastChannel } from './utils/createMulticastChannel';
 
 export { iterifiedUnwrapped, type IterifiedUnwrapped };
@@ -29,7 +29,7 @@ function iterifiedUnwrapped<TNext>(): IterifiedUnwrapped<TNext, void | undefined
 }
 
 type IterifiedUnwrapped<TNextValue, TDoneValue> = {
-  iterable: Iterified<TNextValue, TDoneValue>;
+  iterable: IterifiedIterable<TNextValue, TDoneValue>;
   next: (nextValue: TNextValue) => void;
   done: (returnValue: TDoneValue) => void;
   error: (error?: unknown) => void;


### PR DESCRIPTION
The publicly-exported type name `Iterified` is a bit too general and thus vague, a bit ambiguous as well as this is the name of the library itself and also its main exported function.

This renames it into `IterifiedIterable`, but keeps around (for the foreseen future) the old identical one as deprecated for backwards-compatibility.