### PR TITLE
Move readme subtitle to be on top of the badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Iterified
 
+> Convert any callback-based sequence of values into a full-fledged async iterable
+
 <p>
   <a href="https://github.com/shtaif/iterified/actions/workflows/ci-tests.yaml">
     <img alt="" src="https://github.com/shtaif/iterified/actions/workflows/ci-tests.yaml/badge.svg" />
@@ -9,8 +11,6 @@
   </a>
   <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg" alt="" />
 <p>
-
-> Convert any callback-based sequence of values into a full-fledged async iterable
 
 `iterified` converts any callback-style sequence of zero or more values into an async iterable equivalent. With this, you can take advantage of all the language features and semantics of async iterables, such as playing well with `async`-`await` and `for`-`await`-`of` looping, streamlined error handling with `try-catch` and encapsulatation of resource clean up - for any kind of an asynchronous value stream.
 


### PR DESCRIPTION
Doing this because I've witnessed that external vendors and services, e.g https://www.npmjs.com, which try to display the first sentence in the README.md next to the package's name - are seen showing raw HTML text of the badges since they are kind of the first content that appears on the `README.md` file.

This can be seen here:

![image](https://github.com/shtaif/iterified/assets/6892872/a60ff230-8eb5-4d90-b023-d04c45a847b2)
