### PR TITLE
Fill in some `description` on `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/shtaif/iterified"
   },
-  "description": "",
+  "description": "Convert any callback-based sequence of values into a full-fledged async iterable",
   "engineStrict": true,
   "sideEffects": false,
   "keywords": [


### PR DESCRIPTION
Follows up on top of the recent https://github.com/shtaif/iterified/pull/37, as I found out NPM was showing an excerpt from the start of the `README.md` to begin with was only because of the absence of a `description` entry on the `package.json`. So this PR fills in a proper `description`.