### PR TITLE
Tune release notes configuration

### DIFF
--- a/.github/workflows/release-new-version.yaml
+++ b/.github/workflows/release-new-version.yaml
@@ -39,3 +39,4 @@ jobs:
             @semantic-release/github@8.0.7
             @semantic-release/npm@9.0.2
             @semantic-release/git@10.0.1
+            conventional-changelog-conventionalcommits@^7.0.2

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,10 +14,27 @@
         }
       }
     ],
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
-    "@semantic-release/github",
-    "@semantic-release/npm",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Features", "hidden": false },
+            { "type": "fix", "section": "Bug Fixes", "hidden": false },
+            { "type": "perf", "section": "Performance", "hidden": false },
+            { "type": "refactor", "section": "Refactor", "hidden": false },
+            { "type": "test", "section": "Tests", "hidden": false },
+            { "type": "revert", "section": "Reverts", "hidden": false },
+            { "type": "docs", "section": "Documentation", "hidden": false },
+            { "type": "build", "section": "Build System", "hidden": false }
+          ]
+        }
+      }
+    ],
+    ["@semantic-release/changelog", {}],
+    ["@semantic-release/github", {}],
+    ["@semantic-release/npm", {}],
     [
       "@semantic-release/git",
       {


### PR DESCRIPTION
Tune release notes configuration to include some more types than the default ones, which also directly affects the content that goes into the `CHANGELOG.md` file.
Seen changes are based off of https://github.com/semantic-release/changelog/issues/228#issuecomment-1167931870.