### PR TITLE
Internal logic fix in the multicast channel code (non-affecting public behavior/API whatsoever)

### DIFF
--- a/src/utils/createMulticastChannel.ts
+++ b/src/utils/createMulticastChannel.ts
@@ -66,11 +66,11 @@ function createMulticastChannel<T>(): MulticastChannel<T> {
             return { done: false, value: listHead.item };
           }
 
-          if (channelState === ChannelInternalState.CLOSED) {
-            return { done: true, value: undefined };
-          }
-
-          if (channelState === ChannelInternalState.ERROR) {
+          if (channelState !== ChannelInternalState.ACTIVE) {
+            isIteratorClosed = true;
+            if (channelState === ChannelInternalState.CLOSED) {
+              return { done: true, value: undefined };
+            }
             throw channelErrorValue;
           }
 


### PR DESCRIPTION
Internal logic fix in the multicast channel code (non-affecting public behavior/API whatsoever); ensure to mark a channel's iterator as closed for further pull attempts as soon as it realizes its parent channel itself had already ended/errored out.